### PR TITLE
Bugs in enumSubkeys and readString

### DIFF
--- a/registry.nim
+++ b/registry.nim
@@ -282,11 +282,10 @@ template injectRegKeyReader(handle: RegHandle, key: string,
     status = regGetValue(handle, nil, keyWS, allowedDataTypes, kind.addr,
       buff, size.addr)
   if status == ERROR_MORE_DATA:
-    while status != ERROR_MORE_DATA:
-      # size now stores amount of bytes, required to store value in array
-      buff = realloc(buff, size)
-      status = regGetValue(handle, nil, keyWS, allowedDataTypes, kind.addr,
-        buff, size.addr)
+    # size now stores amount of bytes, required to store value in array
+    buff = realloc(buff, size)
+    status = regGetValue(handle, nil, keyWS, allowedDataTypes, kind.addr,
+      buff, size.addr)
   if status != ERROR_SUCCESS:
     dealloc(buff)
     regThrowOnFailInternal(status)

--- a/registry.nim
+++ b/registry.nim
@@ -198,9 +198,9 @@ iterator enumSubkeys*(handle: RegHandle): string {.sideEffect.} =
   var
     index = 0.DWORD
     sizeChars = queryMaxKeyLength(handle) + 1
-    numCharsReaded = sizeChars
     buff = alloc(sizeChars * sizeof(WinChar))
   while true:
+    var numCharsReaded = sizeChars
     var returnValue = regEnumKeyEx(handle, index, cast[WinString](buff),
       numCharsReaded.addr, cast[ptr DWORD](0.DWORD), cast[WinString](0),
       cast[ptr DWORD](0.DWORD), cast[ptr FILETIME](0.DWORD))

--- a/registry.nim
+++ b/registry.nim
@@ -197,24 +197,25 @@ iterator enumSubkeys*(handle: RegHandle): string {.sideEffect.} =
   ## The key must have been opened with the ``samQueryValue`` access right.
   var
     index = 0.DWORD
-    sizeChars = queryMaxKeyLength(handle) + 1
+    # include terminating NULL:
+    sizeChars = handle.queryMaxKeyLength + 1
     buff = alloc(sizeChars * sizeof(WinChar))
+
   while true:
     var numCharsReaded = sizeChars
     var returnValue = regEnumKeyEx(handle, index, cast[WinString](buff),
       numCharsReaded.addr, cast[ptr DWORD](0.DWORD), cast[WinString](0),
       cast[ptr DWORD](0.DWORD), cast[ptr FILETIME](0.DWORD))
-    # if returnValue == ERROR_MORE_DATA:
-    #   # numCharsReaded now stores num of chars required to store string
-    #   # WITHOUT TERMINATING NULL CHAR. stupid winapi T_T
-    #   echo "realloc, ", sizeChars, " -> ", numCharsReaded + 1
-    #   sizeChars = numCharsReaded + 1
+
+    case returnValue
+    # of ERROR_MORE_DATA:
+    #   sizeChars += 10
     #   buff = realloc(buff, sizeChars * sizeof(WinChar))
     #   continue
-    if returnValue == ERROR_NO_MORE_ITEMS:
+    of ERROR_NO_MORE_ITEMS:
       dealloc(buff)
       break;
-    if returnValue in {ERROR_MORE_DATA, ERROR_SUCCESS}:
+    of ERROR_SUCCESS:
       yield $(cast[WinString](buff))
       inc index
     else:


### PR DESCRIPTION
Hi, while playing around with this nice package I found two bugs. One is that `enumSubkeys` would repeatedly return the same string, unless the next subkey was shorter. I fixed it by resetting `numCharsReaded` before every call `regEnumKeyEx`. I also reordered the function a bit and used `case`.

The other one was in `readString`, which raised an exception due to `ERROR_MORE_DATA`. There was a superfluous line and this case was not handled.

Hope it is OK that I put these different commits together in one pull request, this is my first pull request on GitHub :-).
