### PR TITLE
Change RegHandle to uint for 32 bit compatibility

### DIFF
--- a/winregistry.nim
+++ b/winregistry.nim
@@ -4,7 +4,7 @@
 
 import dynlib, winlean
 type
-  RegHandle* = distinct HANDLE
+  RegHandle* = distinct uint
   RegValueKind* {.size: sizeof(DWORD).} = enum
     regNone = 0
     regSZ = 1


### PR DESCRIPTION
Araq is using uint here, https://github.com/nim-lang/Nim/blob/devel/lib/windows/registry.nim#L15